### PR TITLE
Retry transient deployment health failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,5 +47,5 @@ jobs:
               docker compose -p fxtrade-api up -d db
               docker compose -p fxtrade-api run --rm app alembic upgrade head
               docker compose -p fxtrade-api up -d app
-              curl --fail --silent --show-error --retry 10 --retry-delay 3 --retry-connrefused http://127.0.0.1:8000/health
+              curl --fail --silent --show-error --retry 10 --retry-delay 3 --retry-all-errors http://127.0.0.1:8000/health
               docker compose -p fxtrade-api exec -T app python scripts/seed_data.py http://127.0.0.1:8000'


### PR DESCRIPTION
## What changed

The deployment health probe now uses curl's `--retry-all-errors` option. This retries transient startup failures such as connection resets as well as connection refusals, while retaining the existing 10-attempt limit.

## Why

The first production deployment reached the newly started app before Uvicorn finished initializing. The health request received curl error 56 (`Recv failure: Connection reset by peer`), so the job exited before running the production data seed command. The container completed startup shortly afterward and was healthy.

## Impact

Deployments tolerate expected connection churn during container startup. A persistently unhealthy API still fails the job, and seeding only starts after a successful health response.

## Validation

- `actionlint .github/workflows/deploy.yml`
- `git diff --check`
- confirmed the VM's curl version supports `--retry-all-errors`
- confirmed the currently deployed container is healthy and `/health` succeeds