### PR TITLE
Add dashboard data endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,14 @@ fx-trading-simulator-api/
 | POST | `/api/scenario/` | Create scenario |
 | POST | `/api/scenario/bulk` | Bulk upsert scenarios |
 | POST | `/api/scenario/{id}/check-rates` | Check rate coverage for a scenario |
+| GET | `/api/scenario/{name}/rates` | Get rates at each scenario timestamp |
 | GET | `/api/rate/{datetime}` | Get rates at exact datetime |
 | POST | `/api/rate/bulk` | Bulk upsert rates |
 | POST | `/api/trader/bulk` | Bulk upsert traders |
 | POST | `/api/trade/start/{scenario}/{user_id}` | Start a trading session |
 | POST | `/api/trade/next` | Execute trades and advance time |
 | GET | `/api/trade/session/{session_id}` | Get session details |
+| GET | `/api/trade/session/{session_id}/history` | Get session details and balance history |
 | GET | `/api/trade/sessions/{user_id}` | Get all sessions for a user |
 
 ---

--- a/app/api/scenario.py
+++ b/app/api/scenario.py
@@ -14,12 +14,23 @@ from app.schemas.scenario import (
     ScenarioBulkResponse,
     RateCheckRequest,
     RateCheckResponse,
+    ScenarioRatesResponse,
 )
 from app.services.scenario_service import ScenarioService
 from app.services.rate_service import RateService
 from app.utils.date_utils import add_interval
 
 router = APIRouter()
+
+
+def _scenario_timestamps(scenario) -> list:
+    """Generate the timestamps visited by a scenario."""
+    timestamps = []
+    current = scenario.start_datetime
+    while current <= scenario.end_datetime:
+        timestamps.append(current)
+        current = add_interval(current, scenario.time_interval_seconds)
+    return timestamps
 
 
 @router.get("/", response_model=List[ScenarioResponse])
@@ -41,6 +52,29 @@ async def get_scenario(name: str, db: AsyncSession = Depends(get_db)):
             detail=f"Scenario '{name}' not found"
         )
     return scenario
+
+
+@router.get("/{name}/rates", response_model=ScenarioRatesResponse)
+async def get_scenario_rates(name: str, db: AsyncSession = Depends(get_db)):
+    """Get rates at every timestamp visited by a scenario."""
+    scenario_service = ScenarioService(db)
+    scenario = await scenario_service.get_by_name(name)
+    if not scenario:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Scenario '{name}' not found"
+        )
+
+    rate_service = RateService(db)
+    rates = await rate_service.get_rates_for_timestamps(
+        _scenario_timestamps(scenario)
+    )
+    return ScenarioRatesResponse(
+        name=scenario.name,
+        start_datetime=scenario.start_datetime,
+        end_datetime=scenario.end_datetime,
+        date_to_currency_pair_to_rate=rates,
+    )
 
 
 @router.post("/", response_model=ScenarioResponse, status_code=status.HTTP_201_CREATED)
@@ -122,11 +156,7 @@ async def check_scenario_rates(
         )
 
     # Generate all expected timestamps
-    timestamps = []
-    current = scenario.start_datetime
-    while current <= scenario.end_datetime:
-        timestamps.append(current)
-        current = add_interval(current, scenario.time_interval_seconds)
+    timestamps = _scenario_timestamps(scenario)
 
     currencies = [c.upper() for c in data.currencies]
     rate_service = RateService(db)

--- a/app/api/trade.py
+++ b/app/api/trade.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.session import SessionResponse, SessionListResponse
+from app.schemas.session import SessionResponse, SessionListResponse, SessionHistoryResponse
 from app.schemas.trade import TradeRequest, TradeResponse
 from app.services.scenario_service import ScenarioService
 from app.services.session_service import SessionService
@@ -146,6 +146,30 @@ async def get_session(
 
     balances = await session_service.get_current_balances(session)
     return _build_session_response(session, balances)
+
+
+@router.get("/session/{session_id}/history", response_model=SessionHistoryResponse)
+async def get_session_history(
+    session_id: int,
+    db: AsyncSession = Depends(get_db)
+):
+    """Get session details and every recorded balance snapshot."""
+    session_service = SessionService(db)
+    session = await session_service.get_session(session_id)
+
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session {session_id} not found"
+        )
+
+    balances = await session_service.get_current_balances(session)
+    history = await session_service.get_balance_history(session_id)
+    response = _build_session_response(session, balances)
+    return SessionHistoryResponse(
+        **response.model_dump(),
+        balance_history=history,
+    )
 
 
 @router.get("/sessions/{user_id}", response_model=SessionListResponse)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -7,8 +7,9 @@ from app.schemas.scenario import (
     ScenarioEntry,
     ScenarioBulkUpload,
     ScenarioBulkResponse,
+    ScenarioRatesResponse,
 )
-from app.schemas.session import SessionResponse, SessionListResponse
+from app.schemas.session import SessionResponse, SessionListResponse, SessionHistoryResponse
 from app.schemas.trade import ExchangeRequest, TradeRequest, TradeResponse
 from app.schemas.rate import RateResponse, RateBulkUpload, RateEntry
 from app.schemas.trader import TraderEntry, TraderBulkUpload, TraderBulkResponse
@@ -20,8 +21,10 @@ __all__ = [
     "ScenarioEntry",
     "ScenarioBulkUpload",
     "ScenarioBulkResponse",
+    "ScenarioRatesResponse",
     "SessionResponse",
     "SessionListResponse",
+    "SessionHistoryResponse",
     "ExchangeRequest",
     "TradeRequest",
     "TradeResponse",

--- a/app/schemas/scenario.py
+++ b/app/schemas/scenario.py
@@ -76,6 +76,15 @@ class RateCheckResponse(BaseModel):
     complete: bool
 
 
+class ScenarioRatesResponse(BaseModel):
+    """Scenario metadata and rates at each simulation timestamp."""
+
+    name: str
+    start_datetime: datetime
+    end_datetime: datetime
+    date_to_currency_pair_to_rate: Dict[str, Dict[str, float]]
+
+
 class ScenarioResponse(BaseModel):
     """Schema for scenario response."""
 

--- a/app/schemas/session.py
+++ b/app/schemas/session.py
@@ -30,3 +30,9 @@ class SessionListResponse(BaseModel):
 
     sessions: List[SessionResponse]
     total: int
+
+
+class SessionHistoryResponse(SessionResponse):
+    """Trading session response including every recorded balance snapshot."""
+
+    balance_history: Dict[str, Dict[str, float]]

--- a/app/services/rate_service.py
+++ b/app/services/rate_service.py
@@ -39,6 +39,28 @@ class RateService:
         rates = await self.get_rates_at_timestamp(timestamp)
         return RateMatrix(rates)
 
+    async def get_rates_for_timestamps(
+        self,
+        timestamps: List[datetime],
+    ) -> Dict[str, Dict[str, Decimal]]:
+        """Get rates grouped by timestamp for the requested simulation steps."""
+        if not timestamps:
+            return {}
+
+        result = await self.db.execute(
+            select(Rate)
+            .where(Rate.timestamp.in_(timestamps))
+            .order_by(Rate.timestamp, Rate.currency)
+        )
+
+        rates_by_timestamp: Dict[str, Dict[str, Decimal]] = {}
+        for rate in result.scalars().all():
+            timestamp = rate.timestamp.isoformat()
+            rates_by_timestamp.setdefault(timestamp, {})[
+                f"{rate.currency}/JPY"
+            ] = rate.rate_to_jpy
+        return rates_by_timestamp
+
     async def bulk_upsert(self, entries: List[RateEntry]) -> tuple[int, int]:
         """Bulk insert or update rates.
 

--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -123,6 +123,20 @@ class SessionService:
         balances = result.scalars().all()
         return {b.currency: b.amount for b in balances}
 
+    async def get_balance_history(self, session_id: int) -> Dict[str, Dict[str, Decimal]]:
+        """Get every balance snapshot for a session, grouped by timestamp."""
+        result = await self.db.execute(
+            select(Balance)
+            .where(Balance.session_id == session_id)
+            .order_by(Balance.timestamp, Balance.currency)
+        )
+
+        history: Dict[str, Dict[str, Decimal]] = {}
+        for balance in result.scalars().all():
+            timestamp = balance.timestamp.isoformat()
+            history.setdefault(timestamp, {})[balance.currency] = balance.amount
+        return history
+
     async def execute_trades_and_advance(
         self,
         session: TradingSession,

--- a/tests/test_scenario_api.py
+++ b/tests/test_scenario_api.py
@@ -81,6 +81,54 @@ async def test_get_scenario_not_found(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_get_scenario_rates(client: AsyncClient):
+    """Test getting rates only at timestamps visited by a scenario."""
+    await client.post(
+        "/api/scenario/",
+        json={
+            "name": "RATES_TEST",
+            "start_datetime": "2016-01-04T00:00:00",
+            "end_datetime": "2016-01-06T00:00:00",
+            "time_interval_seconds": 86400,
+        },
+    )
+    await client.post(
+        "/api/rate/bulk",
+        json={
+            "rates": [
+                {"currency": "USD", "timestamp": "2016-01-04T00:00:00", "rate_to_jpy": "118.25"},
+                {"currency": "EUR", "timestamp": "2016-01-04T00:00:00", "rate_to_jpy": "128.50"},
+                {"currency": "USD", "timestamp": "2016-01-04T12:00:00", "rate_to_jpy": "999.00"},
+                {"currency": "USD", "timestamp": "2016-01-05T00:00:00", "rate_to_jpy": "118.50"},
+                {"currency": "USD", "timestamp": "2016-01-06T00:00:00", "rate_to_jpy": "118.75"},
+            ]
+        },
+    )
+
+    response = await client.get("/api/scenario/RATES_TEST/rates")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "RATES_TEST"
+    assert list(data["date_to_currency_pair_to_rate"]) == [
+        "2016-01-04T00:00:00",
+        "2016-01-05T00:00:00",
+        "2016-01-06T00:00:00",
+    ]
+    assert data["date_to_currency_pair_to_rate"]["2016-01-04T00:00:00"] == {
+        "EUR/JPY": 128.5,
+        "USD/JPY": 118.25,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_scenario_rates_not_found(client: AsyncClient):
+    """Test getting rates for a non-existent scenario."""
+    response = await client.get("/api/scenario/NONEXISTENT/rates")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_list_scenarios(client: AsyncClient):
     """Test listing all scenarios."""
     # Create some scenarios

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -214,6 +214,38 @@ async def test_get_session(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_get_session_history(client: AsyncClient):
+    """Test getting all balance snapshots for a session."""
+    await setup_scenario_and_rates(client, "HISTORY_TEST")
+
+    start_response = await client.post("/api/trade/start/HISTORY_TEST/history_trader")
+    session_id = start_response.json()["id"]
+    await client.post(
+        "/api/trade/next",
+        json={"session_id": session_id, "exchange_requests": []},
+    )
+
+    response = await client.get(f"/api/trade/session/{session_id}/history")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == session_id
+    assert data["scenario_name"] == "HISTORY_TEST"
+    assert list(data["balance_history"]) == [
+        "2016-01-04T00:00:00",
+        "2016-01-05T00:00:00",
+    ]
+    assert data["balance_history"]["2016-01-04T00:00:00"]["JPY"] == 1000000
+
+
+@pytest.mark.asyncio
+async def test_get_session_history_not_found(client: AsyncClient):
+    """Test getting history for a non-existent session."""
+    response = await client.get("/api/trade/session/99999/history")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_get_session_not_found(client: AsyncClient):
     """Test getting non-existent session."""
     response = await client.get("/api/trade/session/99999")


### PR DESCRIPTION
## What changed

- Add `GET /api/trade/session/{id}/history` for complete balance snapshots
- Add `GET /api/scenario/{name}/rates` for rates at the timestamps visited by a scenario
- Add response schemas and service queries
- Reuse scenario timestamp generation for rate coverage checks
- Document both endpoints
- Add success and not-found tests for both endpoints

## Why

The dashboard needs complete balance history and scenario rate series, while the existing endpoints expose only current balances and scenario metadata.

## Validation

- `pytest -q` — 39 passed
- `python3 -m compileall -q app tests`
- `git diff --check`