### PR TITLE
Add ipynb code-cell extraction script and extract-ipynb skill

### DIFF
--- a/.claude/skills/extract-ipynb/SKILL.md
+++ b/.claude/skills/extract-ipynb/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: extract-ipynb
+description: ipynb のコードセルだけを .py ファイルに抽出する。ノートブックから Python コードを取り出したい・スクリプト化したいときに使う。
+---
+
+# ipynb からの Python コード抽出
+
+## 手順
+
+1. 専用スクリプト `scripts/extract_ipynb_code.py` を使う（標準ライブラリのみ、依存なし）:
+
+   ```bash
+   # 出力先を省略すると /tmp/<ノートブック名>.py に書き出す
+   python3 scripts/extract_ipynb_code.py <notebook.ipynb> [output.py]
+   ```
+
+   例（document/tmp に抽出する場合）:
+
+   ```bash
+   mkdir -p document/tmp
+   python3 scripts/extract_ipynb_code.py document/colab_template.ipynb document/tmp/colab_template.py
+   ```
+
+   出力先ディレクトリは自動作成されないので、必要なら先に `mkdir -p` する。
+
+2. 抽出後、正しい Python になっているか検証する:
+
+   ```bash
+   python3 -m py_compile <output.py>
+   ```
+
+## スクリプトの仕様
+
+- `cell_type == "code"` のセルのみ抽出（Markdown セルは除外、空セルもスキップ）
+- 各セルの先頭に `# %% [cell N]` の区切りコメントを付ける（元のセル番号が追える。VS Code はこれをセル区切りとして認識する）
+- Jupyter マジック（`%...`）とシェル行（`!...`）はコメントアウトして残す — そのままでは Python として不正なため
+
+## 注意
+
+- リポジトリのノートブックは `document/` 配下にある
+- `document/tmp/` は git 未追跡。コミットに含めたくなければ `.gitignore` に追加する

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,8 @@ Thumbs.db
 # uv
 uv.lock
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (shared skills are tracked)
+.claude/*
+!.claude/skills/
 
 AGENTS.md

--- a/scripts/extract_ipynb_code.py
+++ b/scripts/extract_ipynb_code.py
@@ -1,0 +1,52 @@
+"""Extract code cells from a .ipynb notebook into a .py file.
+
+Usage:
+    python scripts/extract_ipynb_code.py <notebook.ipynb> [output.py]
+
+If output.py is omitted, writes to /tmp/<notebook_name>.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def extract_code(notebook_path: Path) -> str:
+    with notebook_path.open(encoding="utf-8") as f:
+        notebook = json.load(f)
+
+    chunks = []
+    for i, cell in enumerate(notebook.get("cells", []), start=1):
+        if cell.get("cell_type") != "code":
+            continue
+        source = "".join(cell.get("source", []))
+        if not source.strip():
+            continue
+        # Comment out Jupyter magics (%...) and shell commands (!...)
+        # so the output is valid Python
+        lines = [
+            f"# {line}" if line.lstrip().startswith(("%", "!")) else line
+            for line in source.rstrip().splitlines()
+        ]
+        chunks.append(f"# %% [cell {i}]\n" + "\n".join(lines) + "\n")
+
+    return "\n\n".join(chunks) + "\n"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    notebook_path = Path(sys.argv[1])
+    if len(sys.argv) >= 3:
+        output_path = Path(sys.argv[2])
+    else:
+        output_path = Path("/tmp") / (notebook_path.stem + ".py")
+
+    output_path.write_text(extract_code(notebook_path), encoding="utf-8")
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
- `scripts/extract_ipynb_code.py`: ipynb のコードセルだけを .py に抽出するスクリプト（標準ライブラリのみ）
  - Markdown セルと空セルは除外し、各セル先頭に `# %% [cell N]` 区切りを付与
  - Jupyter マジック（`%...`）・シェル行（`!...`）はコメントアウトし、出力が valid Python になるようにする
  - 出力先省略時は `/tmp/<ノートブック名>.py`
- `.claude/skills/extract-ipynb/SKILL.md`: 抽出手順を Claude Code のプロジェクトスキルとして記録
- `.gitignore`: `.claude/*` は除外したまま `.claude/skills/` のみ追跡対象に変更

## 動作確認
- `document/colab_template.ipynb` で実行し、コードセル11個が抽出されることを確認
- 出力ファイルが `python3 -m py_compile` を通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)