### PR TITLE
Stop silently dropping an order for the caller's entire balance

### DIFF
--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -1,7 +1,7 @@
 """Session service for managing trading sessions."""
 
 from datetime import datetime, timedelta
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import select, and_
@@ -207,14 +207,18 @@ class SessionService:
         currency_from = request.currency_from.upper()
         currency_to = request.currency_to.upper()
 
-        # Compare as Decimal, not against the raw float. Balances are Decimal
-        # values quantized to 6 dp, while request.amount arrives from JSON as a
-        # float; comparing the two directly expands the float to its exact
-        # binary value (1000000.1 -> 1000000.099999999976716935634613037109375),
-        # so an order for the caller's entire balance reads as insufficient
-        # funds and is silently dropped. Decimal(str(...)) round-trips the
-        # float's shortest repr and matches the stored value exactly.
-        amount = Decimal(str(request.amount))
+        # Balances are Numeric(20, 6); request.amount arrives from JSON as a
+        # float. Comparing the two directly expands the float to its exact
+        # binary value, so an order for the caller's entire balance reads as
+        # insufficient funds and is silently dropped. Callers compute such an
+        # amount as balance * rate / rate, which lands a fraction of a ulp
+        # either side of the balance, so rounding the float's shortest repr is
+        # not enough on its own -- quantize onto the same 1e-6 grid the
+        # balances and RateMatrix.convert already use. Anything finer than that
+        # cannot be represented in a balance anyway.
+        amount = Decimal(str(request.amount)).quantize(
+            Decimal("0.000001"), rounding=ROUND_HALF_UP
+        )
 
         current_balance = balances.get(currency_from, Decimal("0"))
         if current_balance < amount:

--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -207,12 +207,21 @@ class SessionService:
         currency_from = request.currency_from.upper()
         currency_to = request.currency_to.upper()
 
+        # Compare as Decimal, not against the raw float. Balances are Decimal
+        # values quantized to 6 dp, while request.amount arrives from JSON as a
+        # float; comparing the two directly expands the float to its exact
+        # binary value (1000000.1 -> 1000000.099999999976716935634613037109375),
+        # so an order for the caller's entire balance reads as insufficient
+        # funds and is silently dropped. Decimal(str(...)) round-trips the
+        # float's shortest repr and matches the stored value exactly.
+        amount = Decimal(str(request.amount))
+
         current_balance = balances.get(currency_from, Decimal("0"))
-        if current_balance < request.amount:
+        if current_balance < amount:
             return None
 
         converted_amount, rate = rate_matrix.convert(
-            Decimal(str(request.amount)),
+            amount,
             currency_from,
             currency_to,
         )
@@ -220,7 +229,7 @@ class SessionService:
         if converted_amount is None:
             return None
 
-        balances[currency_from] = current_balance - Decimal(str(request.amount))
+        balances[currency_from] = current_balance - amount
         balances[currency_to] = balances.get(currency_to, Decimal("0")) + converted_amount
 
         return TradeResult(

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -267,3 +267,49 @@ async def test_get_user_sessions(client: AsyncClient):
     data = response.json()
     assert data["total"] >= 2
     assert all(s["user_id"] == "multiuser" for s in data["sessions"])
+
+
+@pytest.mark.asyncio
+async def test_convert_entire_balance_is_not_dropped(client: AsyncClient):
+    """An order for exactly the caller's full balance must execute, not be skipped.
+
+    Balances are stored as Decimal but reported over JSON as float. Comparing the
+    stored Decimal against the raw float expands the float to its exact binary
+    value (8456.659619 -> 8456.65961900000002060551196336746215820312), which
+    reads as larger than the balance -- so every "convert everything" order was
+    silently dropped with no trade and no error.
+    """
+    await setup_scenario_and_rates(client, "FULL_BALANCE_TEST")
+
+    start_response = await client.post("/api/trade/start/FULL_BALANCE_TEST/fulltrader")
+    session_id = start_response.json()["id"]
+
+    # Spend the entire JPY balance on USD.
+    response = await client.post(
+        "/api/trade/next",
+        json={
+            "session_id": session_id,
+            "exchange_requests": [
+                {"currency_from": "JPY", "currency_to": "USD", "amount": 1000000}
+            ],
+        },
+    )
+    assert response.status_code == 200
+    usd_balance = response.json()["balances"]["USD"]
+    assert usd_balance > 0
+
+    # Sell it all back, quoting the balance exactly as the API just reported it.
+    response = await client.post(
+        "/api/trade/next",
+        json={
+            "session_id": session_id,
+            "exchange_requests": [
+                {"currency_from": "USD", "currency_to": "JPY", "amount": usd_balance}
+            ],
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["trades"], "full-balance order was silently dropped"
+    assert data["balances"]["USD"] == pytest.approx(0.0, abs=1e-6)
+    assert data["balances"]["JPY"] > 0

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -313,3 +313,52 @@ async def test_convert_entire_balance_is_not_dropped(client: AsyncClient):
     assert data["trades"], "full-balance order was silently dropped"
     assert data["balances"]["USD"] == pytest.approx(0.0, abs=1e-6)
     assert data["balances"]["JPY"] > 0
+
+
+@pytest.mark.asyncio
+async def test_order_a_hair_above_the_balance_still_executes(client: AsyncClient):
+    """Sub-quantum overshoot must not drop the order, but a real one still must.
+
+    Callers size a "sell everything" order as balance * rate / rate, which lands
+    a fraction of a ulp either side of the balance. Balances are Numeric(20, 6),
+    so an overshoot below 1e-6 is noise, not insufficient funds.
+    """
+    await setup_scenario_and_rates(client, "EPSILON_TEST")
+
+    start_response = await client.post("/api/trade/start/EPSILON_TEST/epsilontrader")
+    session_id = start_response.json()["id"]
+
+    response = await client.post(
+        "/api/trade/next",
+        json={
+            "session_id": session_id,
+            "exchange_requests": [
+                {"currency_from": "JPY", "currency_to": "USD", "amount": 1000000}
+            ],
+        },
+    )
+    usd_balance = response.json()["balances"]["USD"]
+
+    # A hair over the balance, well inside the 1e-6 storage quantum.
+    response = await client.post(
+        "/api/trade/next",
+        json={
+            "session_id": session_id,
+            "exchange_requests": [
+                {"currency_from": "USD", "currency_to": "JPY", "amount": usd_balance + 1e-9}
+            ],
+        },
+    )
+    assert response.json()["trades"], "sub-quantum overshoot was dropped"
+
+    # Genuinely more than the caller holds is still refused.
+    response = await client.post(
+        "/api/trade/next",
+        json={
+            "session_id": session_id,
+            "exchange_requests": [
+                {"currency_from": "USD", "currency_to": "JPY", "amount": 1000.0}
+            ],
+        },
+    )
+    assert response.json()["trades"] == []


### PR DESCRIPTION
## 何が起きていたか

`_execute_single_trade` が、DB 由来の残高（`Numeric(20, 6)` = `Decimal`）とリクエスト由来の `request.amount`（JSON から来た `float`）を直接比較していました。Python はこの比較で float を厳密な2進値に展開するため、**API が直前に報告したのと同じ残高を指定した注文が「残高不足」と判定**されます。

```
DB保存値        1003164.352119
float の厳密値   1003164.352119000046513974666595458984375   → 「不足」と判定
```

しかも `return None` で注文を丸ごと破棄し、取引も返さずエラーも出しません。呼び出し側からは「注文したのに何も起きなかった」としか見えません。

## 影響

「保有している分を全部変換する」注文は、呼び出し側で量を `残高 × レート ÷ レート` として計算するため、**必ず**この誤差を踏みます。#17 のチュートリアル用シナリオ TUTORIAL3 で計測したところ、**471回中469回（99.6%）の注文が消えていました**。模範解答のゴールデンクロス戦略のリターンが 13.7% → 0.3% になります。

チュートリアルに限らず、`document/colab_template.ipynb` を使う参加者が「全額変換」を書いた場合も同じことが起きます。

## 修正

2段階になっています。

**1. `Decimal(str(...))` で比較する。** `str()` は float の最短表現を往復するので、保存値と厳密に一致します。同じ関数内の換算と残高更新は**既に** `Decimal(str(...))` を使っており、比較の行だけが漏れていました。

**2. 残高と同じ 1e-6 グリッドに量子化する。** 1 だけでは不十分でした。`残高 × レート ÷ レート` の往復は残高の**上下どちらにも** 1 ulp ずれ得るため、上振れした場合は `Decimal(str(...))` がその上振れを忠実に保存してしまい、やはり弾かれます。

残高は `Numeric(20, 6)` で、`RateMatrix.convert` も既に同じ `0.000001` で量子化しています。1e-6 未満の上振れは「残高不足」ではなくノイズなので、注文量を同じグリッドに載せて吸収します。**残高より本当に多い注文は従来どおり拒否されます**（挙動は変えていません）。

## 実測

チュートリアルの3シナリオで、模範解答の戦略を API に流して計測しました（バグ1の影響が約定ラグに埋もれないよう、ノートブック側のループは #20 の形にしてあります）。

| | スキップされた注文 | リターン |
|---|---|---|
| 修正前 | シナリオ3で **469/471 (99.6%)** | 0.316% |
| 手順1 のみ | 7/47、4/46 | 9.990% / 13.376% |
| 手順1+2（この PR） | **0/42、0/42** | **8.549% / 13.655%** |

最後の行は、講師用メモが根拠にしている想定値（8.549% / 13.655%）と小数3桁まで一致します。

## テスト

2件追加しました。いずれも修正前は FAILED、修正後は PASSED です。

- `test_convert_entire_balance_is_not_dropped` — 全額 JPY で USD を買い、API が報告した USD 残高をそのまま指定して売り戻す
- `test_order_a_hair_above_the_balance_still_executes` — 残高を 1e-9 だけ超える注文が通ること、および残高より**本当に**多い注文は従来どおり拒否されることの両方を確認

既存テストと合わせて 41 件パスしています。

## 関連

- #20 が、この修正の上に乗るノートブック側の約定タイミングの問題（バグ2）を扱っています
- `document/colab_template.ipynb` の仕様書は main では「amount が所有資産より多い場合、所有資産の全てを変換する」（クランプ）でしたが、#17 で「そのリクエストは実行されません（スキップ）」に書き換えられています。**本当に**残高を超えた注文をクランプすべきかスキップすべきかは、この PR とは独立した仕様判断として残ります

🤖 Generated with [Claude Code](https://claude.com/claude-code)
