### PR TITLE
Hide EVAL scenarios from the scenario listing

### DIFF
--- a/app/api/scenario.py
+++ b/app/api/scenario.py
@@ -35,10 +35,13 @@ def _scenario_timestamps(scenario) -> list:
 
 @router.get("/", response_model=List[ScenarioResponse])
 async def list_scenarios(db: AsyncSession = Depends(get_db)):
-    """List all scenarios."""
+    """List all scenarios, except evaluation ones (names containing EVAL)."""
     service = ScenarioService(db)
     scenarios = await service.get_all()
-    return scenarios
+    # Evaluation scenarios are announced during the event; keep them out of the
+    # listing so participants cannot discover the names in advance. Direct
+    # lookups by name (and session start) still work once a name is announced.
+    return [s for s in scenarios if "EVAL" not in s.name.upper()]
 
 
 @router.get("/{name}", response_model=ScenarioResponse)

--- a/tests/test_scenario_api.py
+++ b/tests/test_scenario_api.py
@@ -276,3 +276,28 @@ async def test_bulk_upload_scenarios_update(client: AsyncClient):
     updated = await client.get("/api/scenario/BULK_UPDATE")
     assert updated.json()["time_interval_seconds"] == 3600
     assert updated.json()["initial_balance"] == 500000
+
+
+@pytest.mark.asyncio
+async def test_list_scenarios_hides_eval(client: AsyncClient):
+    """Scenario names containing EVAL are hidden from the listing but remain
+    directly fetchable by name (so session start keeps working once announced)."""
+    for name in ["EVAL_HIDDEN", "VISIBLE_X"]:
+        await client.post(
+            "/api/scenario/",
+            json={
+                "name": name,
+                "start_datetime": "2016-01-04T00:00:00",
+                "end_datetime": "2016-01-08T00:00:00",
+                "time_interval_seconds": 86400,
+                "initial_balance": 1000000,
+            }
+        )
+
+    names = [s["name"] for s in (await client.get("/api/scenario/")).json()]
+    assert "VISIBLE_X" in names
+    assert "EVAL_HIDDEN" not in names
+
+    response = await client.get("/api/scenario/EVAL_HIDDEN")
+    assert response.status_code == 200
+    assert response.json()["name"] == "EVAL_HIDDEN"


### PR DESCRIPTION
## 概要
`GET /api/scenario/` から名前に EVAL を含むシナリオ（大文字小文字不問）を除外します。評価シナリオ名は当日発表のため、事前に一覧から発見できないようにする対策です（リハーサル所見 #8/#11 の一部）。

- 名前の直接指定（`GET /api/scenario/{name}`）と `/start` は**発表後そのまま使えます**（テストで固定）
- 全 43 テストパス

## ⚠️ マージ時の注意
- **マージ = 自動デプロイ**で即座に一覧から EVAL0〜11 が消えます（参加者の Q1-1 出力にも出なくなる）
- これは「名前の事前発見」を塞ぐだけです。`/{name}/rates` と public repo の `data/rates.csv` の露出（所見 #8）は別対応（秘密シナリオ方式）が前提

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK