### PR TITLE
Block rate disclosure for evaluation scenarios

### DIFF
--- a/app/api/rate.py
+++ b/app/api/rate.py
@@ -5,7 +5,10 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import select
+
 from app.database import get_db
+from app.models.scenario import Scenario
 from app.schemas.rate import RateResponse, RateBulkUpload, RateBulkResponse
 from app.services.rate_service import RateService
 from app.utils.date_utils import parse_datetime
@@ -25,6 +28,23 @@ async def get_rates(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid timestamp format: {timestamp}"
+        )
+
+    # Reject lookups inside an evaluation scenario's window: iterating this
+    # endpoint minute by minute would reconstruct the scored day in advance.
+    # In-game rates are unaffected (POST /api/trade/next returns them as the
+    # session advances).
+    result = await db.execute(
+        select(Scenario.id).where(
+            Scenario.name.ilike("%eval%"),
+            Scenario.start_datetime <= dt,
+            Scenario.end_datetime >= dt,
+        ).limit(1)
+    )
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Rates inside an evaluation scenario window are not disclosed"
         )
 
     service = RateService(db)

--- a/app/api/scenario.py
+++ b/app/api/scenario.py
@@ -60,6 +60,13 @@ async def get_scenario(name: str, db: AsyncSession = Depends(get_db)):
 @router.get("/{name}/rates", response_model=ScenarioRatesResponse)
 async def get_scenario_rates(name: str, db: AsyncSession = Depends(get_db)):
     """Get rates at every timestamp visited by a scenario."""
+    # Evaluation scenario rates must not be disclosed in advance: a single
+    # request here would reveal the whole day the participants are scored on.
+    if "EVAL" in name.upper():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Rates for evaluation scenarios are not disclosed"
+        )
     scenario_service = ScenarioService(db)
     scenario = await scenario_service.get_by_name(name)
     if not scenario:

--- a/tests/test_scenario_api.py
+++ b/tests/test_scenario_api.py
@@ -301,3 +301,53 @@ async def test_list_scenarios_hides_eval(client: AsyncClient):
     response = await client.get("/api/scenario/EVAL_HIDDEN")
     assert response.status_code == 200
     assert response.json()["name"] == "EVAL_HIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_eval_scenario_rates_forbidden(client: AsyncClient):
+    """The full-rates dump is refused for evaluation scenarios (403)."""
+    for name in ["EVAL_BLOCKED", "OPEN_SCENARIO"]:
+        await client.post(
+            "/api/scenario/",
+            json={
+                "name": name,
+                "start_datetime": "2016-01-04T00:00:00",
+                "end_datetime": "2016-01-08T00:00:00",
+                "time_interval_seconds": 86400,
+                "initial_balance": 1000000,
+            }
+        )
+
+    response = await client.get("/api/scenario/EVAL_BLOCKED/rates")
+    assert response.status_code == 403
+
+    response = await client.get("/api/scenario/OPEN_SCENARIO/rates")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rate_lookup_forbidden_inside_eval_window(client: AsyncClient):
+    """GET /api/rate/{ts} is refused for timestamps inside an EVAL scenario."""
+    await client.post(
+        "/api/scenario/",
+        json={
+            "name": "EVAL_WINDOW",
+            "start_datetime": "2016-01-04T00:00:00",
+            "end_datetime": "2016-01-06T00:00:00",
+            "time_interval_seconds": 86400,
+            "initial_balance": 1000000,
+        }
+    )
+    await client.post(
+        "/api/rate/bulk",
+        json={"rates": [
+            {"currency": "USD", "timestamp": "2016-01-05T00:00:00", "rate_to_jpy": "118.25"},
+            {"currency": "USD", "timestamp": "2016-02-01T00:00:00", "rate_to_jpy": "119.00"},
+        ]}
+    )
+
+    response = await client.get("/api/rate/2016-01-05T00:00:00")
+    assert response.status_code == 403
+
+    response = await client.get("/api/rate/2016-02-01T00:00:00")
+    assert response.status_code == 200

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -341,3 +341,19 @@ async def test_get_user_sessions(client: AsyncClient):
     data = response.json()
     assert data["total"] >= 2
     assert all(s["user_id"] == "multiuser" for s in data["sessions"])
+
+
+@pytest.mark.asyncio
+async def test_eval_scenario_gameplay_unaffected(client: AsyncClient):
+    """Sessions on EVAL scenarios still run and /next still returns rates."""
+    await setup_scenario_and_rates(client, "EVAL_PLAY")
+
+    start = await client.post("/api/trade/start/EVAL_PLAY/testuser")
+    assert start.status_code == 200
+
+    step = await client.post(
+        "/api/trade/next",
+        json={"session_id": start.json()["id"], "exchange_requests": []}
+    )
+    assert step.status_code == 200
+    assert "USD" in step.json()["rates"]


### PR DESCRIPTION
## 概要
リハーサル所見 #8 の対策 B。評価（EVAL）シナリオのレートを事前に取得できる 2 つの穴を塞ぎます。

- `GET /api/scenario/{name}/rates`: 名前に EVAL を含むシナリオは **403**（1 リクエストで採点日の全レートが取れていた）
- `GET /api/rate/{timestamp}`: タイムスタンプが**いずれかの EVAL シナリオの期間内**なら **403**（1 分ずつ辿る復元も不可に）

## 影響調査（済み）
- `/{name}/rates` を呼ぶノートブック・スクリプトは**ゼロ**（全教材・scripts/ を走査済み）→ 教材への影響なし
- `/api/rate/{ts}` はノートブックから呼ばれるが: tutorial は EVAL 日に到達しない設計、colab_template のプリフェッチは非 200 を黙ってスキップする実装のため無害
- **ゲームプレイは無影響**: `POST /api/trade/next` は従来どおり進行中のレートを返す（EVAL シナリオで start→next が動くテストで固定）

## テスト
新規 3 本を含む全 46 テストパス。

## 残る露出（別対応）
- public repo の `data/rates.csv` に EVAL 日データが残存（所見 #8-A、秘密シナリオ方式が本命）
- 変更系 API の認証なし（#8-C）

## マージ時の注意
マージ = 自動デプロイで即有効化されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK