### PR TITLE
(要レビュー)EVALシナリオの提出を１度きりに制限する

### DIFF
--- a/app/api/trade.py
+++ b/app/api/trade.py
@@ -9,7 +9,7 @@ from app.database import get_db
 from app.schemas.session import SessionResponse, SessionListResponse, SessionHistoryResponse
 from app.schemas.trade import TradeRequest, TradeResponse
 from app.services.scenario_service import ScenarioService
-from app.services.session_service import SessionService
+from app.services.session_service import AlreadySubmittedError, SessionService
 
 router = APIRouter()
 
@@ -71,6 +71,11 @@ async def start_session(
     except PermissionError as e:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(e)
+        )
+    except AlreadySubmittedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
             detail=str(e)
         )
 

--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -48,6 +48,10 @@ ALLOWED_USER_IDS = frozenset([
 ])
 
 
+class AlreadySubmittedError(Exception):
+    """A completed evaluation session already exists for this user/scenario."""
+
+
 class SessionService:
     """Service for trading session operations."""
 
@@ -63,6 +67,24 @@ class SessionService:
         """Start a new trading session for a user in a scenario."""
         # Reject users that are not on the allowlist
         self._check_user_allowed(user_id)
+
+        # Evaluation scenarios accept one submission per user: once a
+        # completed session exists, further starts are rejected (409).
+        # Incomplete sessions (crashed kernel, dropped connection) may be
+        # restarted, so genuine accidents need no operator intervention.
+        if "EVAL" in scenario.name.upper():
+            result = await self.db.execute(
+                select(TradingSession.id).where(
+                    TradingSession.user_id == user_id,
+                    TradingSession.scenario_id == scenario.id,
+                    TradingSession.is_complete.is_(True),
+                ).limit(1)
+            )
+            if result.scalar_one_or_none() is not None:
+                raise AlreadySubmittedError(
+                    f"Scenario '{scenario.name}' has already been submitted by "
+                    f"'{user_id}' (evaluation runs are accepted once)"
+                )
 
         # Create session
         session = TradingSession(

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -381,3 +381,50 @@ async def test_history_cache_control(client: AsyncClient):
     r = await client.get(f"/api/trade/session/{sid}/history")
     assert r.status_code == 200
     assert "immutable" in r.headers.get("cache-control", "")
+async def _run_to_completion(client: AsyncClient, session_id: int) -> None:
+    for _ in range(10):
+        resp = await client.post(
+            "/api/trade/next",
+            json={"session_id": session_id, "exchange_requests": []}
+        )
+        assert resp.status_code == 200
+        if resp.json()["is_complete"]:
+            return
+    raise AssertionError("session did not complete within 10 steps")
+
+
+@pytest.mark.asyncio
+async def test_eval_second_submission_rejected(client: AsyncClient):
+    """A completed EVAL session blocks further submissions (409)."""
+    await setup_scenario_and_rates(client, "EVAL_ONCE")
+
+    start = await client.post("/api/trade/start/EVAL_ONCE/testuser")
+    assert start.status_code == 200
+    await _run_to_completion(client, start.json()["id"])
+
+    retry = await client.post("/api/trade/start/EVAL_ONCE/testuser")
+    assert retry.status_code == 409
+    assert "already been submitted" in retry.json()["detail"]
+
+    # A different user is unaffected
+    other = await client.post("/api/trade/start/EVAL_ONCE/trader1")
+    assert other.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_eval_incomplete_session_can_restart(client: AsyncClient):
+    """An incomplete (crashed) EVAL run does not block a restart."""
+    await setup_scenario_and_rates(client, "EVAL_RETRY")
+
+    first = await client.post("/api/trade/start/EVAL_RETRY/testuser")
+    assert first.status_code == 200
+    step = await client.post(
+        "/api/trade/next",
+        json={"session_id": first.json()["id"], "exchange_requests": []}
+    )
+    assert step.status_code == 200
+    assert step.json()["is_complete"] is False
+
+    second = await client.post("/api/trade/start/EVAL_RETRY/testuser")
+    assert second.status_code == 200
+    assert second.json()["id"] != first.json()["id"]


### PR DESCRIPTION
## 概要
評価シナリオの「提出は 1 回限り」ルールをサーバー側で強制します（**緩和版**を採用）。

- EVAL シナリオで**完走済み（is_complete=true）セッション**を持つユーザーの再 start は **409 Conflict**
- **未完走セッション（kernel 落ち・切断等の事故）は運営の介入なしで再実行可能**
- 他ユーザー・TEST/TUTORIAL 系は無制限のまま

## テスト
新規 2 本（完走後の 409／未完走の再実行可＋他ユーザー無影響）を含む全 48 テストパス。

## 留意点（設計判断済み）
- 緩和版のため「途中まで実行してレートを覗く → 中断 → 再実行」は理論上可能（厳格版とのトレードオフとして許容）。不審な未完走の多発は `GET /api/trade/sessions/{user_id}` で運営が確認できる
- 完走後の救済（やり直し許可）は運営が DB から該当セッションを削除する運用

## マージ時の注意
マージ = 自動デプロイで即有効化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK