### PR TITLE
Run uvicorn with multiple workers (configurable, default 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ COPY . .
 EXPOSE 8000
 
 # Run the application
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# ワーカー数は UVICORN_WORKERS 環境変数で調整（既定 2 = 現行 e2-medium の 2 vCPU 分）。
+# VM をスケールアップしたら vCPU 数に合わせて上げる（compose の environment か -e で指定）。
+# shell 形式にして環境変数を展開する。
+CMD uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-2}


### PR DESCRIPTION
## 問題（負荷テストで判明）
app が **uvicorn 1 ワーカー**で起動しており、VM の 2 vCPU のうち **1 コアしか使っていなかった**。負荷テスト実測で app CPU が ~100%（1 コア分）で頭打ち、DB・メモリ・接続数は余裕。並列 1→3→5 で 1 人あたり完走が 34s→58s→84s と比例悪化。

## 変更
Dockerfile の CMD を環境変数対応に：
```
CMD uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-2}
```
- 既定 **2**（現行 e2-medium の 2 vCPU 分）→ **追加料金ゼロで並列耐性が理論上 2 倍**
- VM をスケールアップしたら `UVICORN_WORKERS` を vCPU 数に合わせるだけ（リビルド不要）

## 効果の確認
- 環境変数展開は検証済み（設定時 4 / 既定 2）
- **実効果はデプロイ後に負荷テスト（scripts/loadtest/）で workers 1 vs 2 を比較して確認する**

## 補足
- ワーカーを増やすとメモリは N 倍（このアプリは 1 ワーカー ≒ 90MB と軽く、余裕）
- コア数を超えるワーカーは無駄。**ワーカー数 ≒ vCPU 数が最適**
- deploy 時に compose の environment で `UVICORN_WORKERS` を明示すると当日調整しやすい

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK