### PR TITLE
Configure the DB connection pool (prevent exhaustion under many workers)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,13 @@ class Settings(BaseSettings):
     default_initial_balance: float = 1000000.0
     default_time_interval_seconds: int = 86400  # 1 day
 
+    # DB connection pool (per uvicorn worker). With N workers the DB sees
+    # N*(pool_size+max_overflow) connections at most; keep that under
+    # Postgres max_connections (default 100). Tune via env vars.
+    db_pool_size: int = 5
+    db_max_overflow: int = 5
+    db_pool_timeout: int = 30
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/app/database.py
+++ b/app/database.py
@@ -14,6 +14,10 @@ async_engine = create_async_engine(
     settings.database_url,
     echo=settings.debug,
     future=True,
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
+    pool_timeout=settings.db_pool_timeout,
+    pool_pre_ping=True,   # 切れた接続を掴んで 500 になる事故を防ぐ
 )
 
 # Async session factory


### PR DESCRIPTION
## 背景
負荷テストで app を uvicorn 8 ワーカーにした結果、各ワーカーが独自のプールを持つため **DB 接続が最大 8×(5+10)=120** に膨らみ、Postgres の `max_connections`（既定 100）を超える恐れが判明。

## 変更
- `db_pool_size` / `db_max_overflow` / `db_pool_timeout` を config に追加（環境変数で可変、既定 5/5/30）
  → 1 ワーカーあたり最大 10 接続。workers=8 でも 80 で、100 未満に収まる
- `pool_pre_ping=True` を追加 → 切れた接続を掴んで 500 になる事故を防ぐ

## 位置づけ
これは**安定化**（接続枯渇・切断による 500 の防止）であって、**スループット改善ではない**。負荷テストの実測では DB CPU が 1 コアで律速しており、速くするには DB への CPU 割り当て（app/DB 分離等）が本筋。

## テスト
全 46 テストパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK