### PR TITLE
Runbook §5-5: app load-test results and day-of scale-up

### DIFF
--- a/infra-setup/運営手順.md
+++ b/infra-setup/運営手順.md
@@ -155,3 +155,49 @@ gcloud compute instances start fx-tljh --project=fx-itnern --zone=asia-northeast
 | メモリ | 55GB | 64GB（OS+Hub 約 3GB） |
 | ディスク | 110GB | 128GB（OS+TLJH 約 8GB） |
 | CPU | — | 同時に重い処理 8 人まで快適 |
+
+### 5-5. app/DB VM（fx-trade-api-ssd）の負荷とスケールアップ
+
+app サーバの同時実行耐性。負荷テストは `scripts/loadtest/`（run_session.py / run_parallel.py）。
+
+**構成のポイント**
+- app（FastAPI/uvicorn）と DB（Postgres）が**同じ VM に同居**（e2-medium = 2 vCPU / 4GB）
+- uvicorn のワーカー数は Dockerfile の `UVICORN_WORKERS`（既定 2）。**ワーカー数 ≒ vCPU 数が最適**
+- DB プールは 1 ワーカーあたり最大 10 接続（`db_pool_size`+`db_max_overflow`）。workers=8 でも 80 で Postgres 上限 100 未満
+
+**負荷テスト実測（2026-09-06、TEST0・noop・外部 IP 経由、1 セッション=1,439 tick）**
+
+| 構成 | 並列1 | 並列5 | 並列10 | 並列20 | ボトルネック |
+|---|---|---|---|---|---|
+| e2-medium / workers 1（旧） | 34s | 84s | — | — | app CPU 1 コア飽和（100%） |
+| e2-medium / workers 2 | 37s | 104s | — | — | app CPU 2 コア飽和（200%） |
+| **e2-standard-8 / workers 8** | 38s | 40s | **38s** | 60s | **並列20で DB CPU が 100% 律速に移行**（app は 500%/800% でまだ余力） |
+
+→ **e2-standard-8 + workers 8 なら並列10まで単発同等、20でも実用範囲**。50 人は完全同時が稀なので捌ける見込み。
+それ以上速くするには app/DB 分離（DB に専用 CPU）が本筋だが、イベント規模では不要。
+
+**イベント当日のスケールアップ手順**（IP は静的予約で不変。app 停止を伴う）
+
+```
+D=/home/ky2001/fxtrade-api
+# 1. app 停止
+gcloud compute ssh fx-trade-api-ssd --project=fx-itnern --zone=asia-northeast1-b \
+  --command="sudo docker compose --project-directory $D down"
+# 2. compose の UVICORN_WORKERS を 8 に（cd 不可なので sed で。無ければ APP_ENV の後に追記）
+gcloud compute ssh fx-trade-api-ssd --project=fx-itnern --zone=asia-northeast1-b \
+  --command="sudo sed -i 's/UVICORN_WORKERS: \"2\"/UVICORN_WORKERS: \"8\"/' $D/docker-compose.yml"
+# 3. VM を e2-standard-8 へ
+gcloud compute instances stop fx-trade-api-ssd --project=fx-itnern --zone=asia-northeast1-b
+gcloud compute instances set-machine-type fx-trade-api-ssd --project=fx-itnern --zone=asia-northeast1-b --machine-type=e2-standard-8
+gcloud compute instances start fx-trade-api-ssd --project=fx-itnern --zone=asia-northeast1-b
+# 4. app 起動 + health（restart ポリシー無しなので手動起動が必須）
+gcloud compute ssh fx-trade-api-ssd --project=fx-itnern --zone=asia-northeast1-b \
+  --command="sudo docker compose --project-directory $D up -d && sleep 6 && curl -sf http://localhost:8000/health"
+```
+
+**⚠️ イベント後は必ず e2-medium + workers 2 に戻す**（上記の逆手順。e2-standard-8 は e2-medium より月 +約 2.4 万円）。
+戻すときは machine-type だけでなく `UVICORN_WORKERS` も 2 に戻すこと（2 vCPU に 8 ワーカーは奪い合いで逆効果）。
+
+**注意**
+- 負荷テストは balances を大量に増やす → テスト後・イベント前に `06_truncate_balances.sh` で掃除
+- テスト用 user_id は許可リスト内の `latency-check` を使う（参加者 ID を汚さない）


### PR DESCRIPTION
負荷調査の結果と当日のスケールアップ手順を運営手順.md §5-5 に記録（ドキュメントのみ）。

## 内容
- **負荷テスト実測表**（2026-09-06、scripts/loadtest/ で計測）
  - e2-medium/workers1 → app CPU 1コア飽和 / workers2 → 2コア飽和
  - **e2-standard-8/workers8 → 並列10まで単発同等、20 で DB CPU が律速に移行**
- **当日のスケールアップ手順**（down → workers=8 → VM 変更 → up、IP 不変、手動起動必須）
- **⚠️ イベント後は e2-medium + workers 2 に戻す**（月 +2.4万円回避）
- 注意: balances 掃除・latency-check 使用

## 関連
- PR #38（uvicorn workers 化、マージ済み）／ PR #39（DB プール設定）と一連

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK