### PR TITLE
Allow admin IDs (tonkou, kein) to start sessions

### DIFF
--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -43,6 +43,8 @@ ALLOWED_USER_IDS = frozenset([
     "tester-7", "tester-8",
     # ops / e2e
     "testuser", "demouser", "yukiyk", "produser", "latency-check",
+    # admins (TLJH の管理者。動作確認・戦略試走で API を叩けるように)
+    "tonkou", "kein",
 ])
 
 


### PR DESCRIPTION
TLJH の管理者 tonkou / kein が API 許可リスト（ALLOWED_USER_IDS）に無く、セッション開始で 403 になっていた（admin ≠ トレード参加者のため）。動作確認・戦略試走のため許可リストに追加。

- traders テーブルへの登録は先行実施済み（FK 制約対応、単体では無害）
- **403 が解けるのはデプロイ後**。マージ=自動デプロイで反映
- 46 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK