### PR TITLE
Cache-Control for history and scenario-rates (offload the UI's read load)

### DIFF
--- a/app/api/scenario.py
+++ b/app/api/scenario.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -58,7 +58,7 @@ async def get_scenario(name: str, db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/{name}/rates", response_model=ScenarioRatesResponse)
-async def get_scenario_rates(name: str, db: AsyncSession = Depends(get_db)):
+async def get_scenario_rates(name: str, response: Response, db: AsyncSession = Depends(get_db)):
     """Get rates at every timestamp visited by a scenario."""
     # Evaluation scenario rates must not be disclosed in advance: a single
     # request here would reveal the whole day the participants are scored on.
@@ -67,6 +67,8 @@ async def get_scenario_rates(name: str, db: AsyncSession = Depends(get_db)):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Rates for evaluation scenarios are not disclosed"
         )
+    # A scenario's rates are immutable historical data -> cache them hard.
+    response.headers["Cache-Control"] = "public, max-age=86400, immutable"
     scenario_service = ScenarioService(db)
     scenario = await scenario_service.get_by_name(name)
     if not scenario:

--- a/app/api/trade.py
+++ b/app/api/trade.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -157,6 +157,7 @@ async def get_session(
 @router.get("/session/{session_id}/history", response_model=SessionHistoryResponse)
 async def get_session_history(
     session_id: int,
+    response: Response,
     db: AsyncSession = Depends(get_db)
 ):
     """Get session details and every recorded balance snapshot."""
@@ -171,9 +172,17 @@ async def get_session_history(
 
     balances = await session_service.get_current_balances(session)
     history = await session_service.get_balance_history(session_id)
-    response = _build_session_response(session, balances)
+
+    # A completed session's history never changes -> cache it hard.
+    # An in-progress session grows on every /next -> never cache.
+    if session.is_complete:
+        response.headers["Cache-Control"] = "public, max-age=86400, immutable"
+    else:
+        response.headers["Cache-Control"] = "no-store"
+
+    session_response = _build_session_response(session, balances)
     return SessionHistoryResponse(
-        **response.model_dump(),
+        **session_response.model_dump(),
         balance_history=history,
     )
 

--- a/tests/test_scenario_api.py
+++ b/tests/test_scenario_api.py
@@ -351,3 +351,17 @@ async def test_rate_lookup_forbidden_inside_eval_window(client: AsyncClient):
 
     response = await client.get("/api/rate/2016-02-01T00:00:00")
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_scenario_rates_cache_control(client: AsyncClient):
+    """Scenario rates carry an immutable Cache-Control header."""
+    await client.post("/api/scenario/", json={
+        "name": "RATES_CACHE", "start_datetime": "2016-01-04T00:00:00",
+        "end_datetime": "2016-01-05T00:00:00", "time_interval_seconds": 86400,
+        "initial_balance": 1000000})
+    await client.post("/api/rate/bulk", json={"rates": [
+        {"currency": "USD", "timestamp": "2016-01-04T00:00:00", "rate_to_jpy": "118.25"}]})
+    r = await client.get("/api/scenario/RATES_CACHE/rates")
+    assert r.status_code == 200
+    assert "immutable" in r.headers.get("cache-control", "")

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -357,3 +357,27 @@ async def test_eval_scenario_gameplay_unaffected(client: AsyncClient):
     )
     assert step.status_code == 200
     assert "USD" in step.json()["rates"]
+
+
+@pytest.mark.asyncio
+async def test_history_cache_control(client: AsyncClient):
+    """Completed session history is cacheable; in-progress is not."""
+    await setup_scenario_and_rates(client, "CACHE_TEST")
+    start = await client.post("/api/trade/start/CACHE_TEST/testuser")
+    sid = start.json()["id"]
+
+    # in-progress -> no-store
+    r = await client.get(f"/api/trade/session/{sid}/history")
+    assert r.status_code == 200
+    assert "no-store" in r.headers.get("cache-control", "")
+
+    # complete it
+    for _ in range(10):
+        resp = await client.post("/api/trade/next", json={"session_id": sid, "exchange_requests": []})
+        if resp.json()["is_complete"]:
+            break
+
+    # completed -> immutable
+    r = await client.get(f"/api/trade/session/{sid}/history")
+    assert r.status_code == 200
+    assert "immutable" in r.headers.get("cache-control", "")


### PR DESCRIPTION
UI（fxapp.netlify.app）は Netlify プロキシ経由で API を叩いており（`cache-status: Netlify Edge` を実測確認）、参照系レスポンスに Cache-Control を付ければ CDN/ブラウザでキャッシュされ app/DB 負荷を下げられる。

## 変更
- `GET /session/{id}/history`: **完了済みは** `public, max-age=86400, immutable`（履歴は不変）／進行中は `no-store`（/next で伸びるため）
- `GET /scenario/{name}/rates`: 常に `immutable`（レートは不変の履歴データ）。EVAL は従来どおり 403

## 設計判断
完了/進行中の区別は app（is_complete）でしか判断できないため、netlify.toml の一律ルールではなく **app の Cache-Control が正しい置き場所**（一律だと進行中セッションまで固まって事故る）。

## テスト
新規 2 本（完了→immutable / 進行中→no-store / rates→immutable）含む 48 テストパス。

## マージ後
本番で `curl -I` して `cache-status: hit` が出るか実測し、Netlify が尊重しているか確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKf8hWwgtLcQEAnZKE5LUK