### PR TITLE
Remove duplicated comment line in day2 cell 10

### DIFF
--- a/document/day2/day2.ipynb
+++ b/document/day2/day2.ipynb
@@ -603,7 +603,6 @@
    },
    "outputs": [],
    "source": [
-    "# 本番提出用\n",
     "# 本番提出用（当日、評価シナリオ名を EVAL_TEST_CASES に入れてから実行）\n",
     "# eval_submission(EVAL_TEST_CASES, ContrarianStrategySession, x=5, y=30)"
    ]


### PR DESCRIPTION
day2.ipynb の cell 10 で「# 本番提出用」のコメントが 2 行重複していたため、旧い 1 行目を削除。#43 で説明付きの行を追加した際に元の行が残っていたもの。コード行の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BCQT83C1HATbRY5qeZd9W