### PR TITLE
day2: eval_submission hardening (placeholder example, error detail, do-not-edit cell)

### DIFF
--- a/document/day2/day2.ipynb
+++ b/document/day2/day2.ipynb
@@ -604,7 +604,7 @@
    "outputs": [],
    "source": [
     "# 本番提出用（当日、評価シナリオ名を EVAL_TEST_CASES に入れてから実行）\n",
-    "# eval_submission(EVAL_TEST_CASES, YourStrategyClass, x=5, y=30)"
+    "# eval_submission(EVAL_TEST_CASES, YourStrategyClass)"
    ]
   }
  ],

--- a/document/day2/day2.ipynb
+++ b/document/day2/day2.ipynb
@@ -604,7 +604,7 @@
    "outputs": [],
    "source": [
     "# 本番提出用（当日、評価シナリオ名を EVAL_TEST_CASES に入れてから実行）\n",
-    "# eval_submission(EVAL_TEST_CASES, ContrarianStrategySession, x=5, y=30)"
+    "# eval_submission(EVAL_TEST_CASES, YourStrategyClass, x=5, y=30)"
    ]
   }
  ],


### PR DESCRIPTION
## 変更内容（document/day2/day2.ipynb）
1. **本番提出用セル**: `# eval_submission(EVAL_TEST_CASES, ContrarianStrategySession, x=5, y=30)` → `# eval_submission(EVAL_TEST_CASES, YourStrategyClass)`
   - 実在クラスのままだと誤ってコメントを外して実行した場合にサンプル戦略で本番提出が通ってしまう。YourStrategyClass は存在しないので NameError で止まる
   - `x=5, y=30` は Contrarian 専用の引数で、自作クラスに付けたまま実行すると TypeError になるため削除
2. **BaseTradingSession.__init__**: セッション開始が 200 以外のとき、`raise_for_status()` の前にサーバの `detail` を表示する（提出済み 409・シナリオ名誤り 404・未登録 ID 403 の理由が見える。409 の文言は #51 で日本語化）
3. **eval_submission を独立セルへ移動**: cell 4 は BaseTradingSession のみにし、eval_submission は本番提出用セルの直前（cell 10）に移動。先頭に「原則として編集しないでください」のバナーコメントを追加。関数本体の変更なし

## セル構成（変更後）
- cell 4: セッションの基底クラス（BaseTradingSession）
- cell 5〜8: 解答例
- cell 9: 戦略アイデア（markdown）
- cell 10: 評価提出処理（eval_submission、編集禁止バナー付き）
- cell 11: 本番提出用（コメントアウトされた呼び出し）

## 確認
- nbformat validate OK
- cell 1〜4 と 10 を exec し、input をモックして eval_submission を 6 ケース検証（5 件チェック・確認プロンプト・TEST 直行）すべて通過
- 本番 API に対し EVALX（404）と未登録 ID（403）で detail が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BCQT83C1HATbRY5qeZd9W