### PR TITLE
Make the EVAL already-submitted (409) message clear and Japanese

### DIFF
--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -82,8 +82,8 @@ class SessionService:
             )
             if result.scalar_one_or_none() is not None:
                 raise AlreadySubmittedError(
-                    f"Scenario '{scenario.name}' has already been submitted by "
-                    f"'{user_id}' (evaluation runs are accepted once)"
+                    f"評価シナリオ '{scenario.name}' は user_id '{user_id}' で提出済みです。"
+                    "評価の提出は 1 回限りのため、同じシナリオは再実行できません。"
                 )
 
         # Create session

--- a/tests/test_trade_api.py
+++ b/tests/test_trade_api.py
@@ -404,7 +404,8 @@ async def test_eval_second_submission_rejected(client: AsyncClient):
 
     retry = await client.post("/api/trade/start/EVAL_ONCE/testuser")
     assert retry.status_code == 409
-    assert "already been submitted" in retry.json()["detail"]
+    assert "提出済み" in retry.json()["detail"]
+    assert "EVAL_ONCE" in retry.json()["detail"]
 
     # A different user is unaffected
     other = await client.post("/api/trade/start/EVAL_ONCE/trader1")


### PR DESCRIPTION
## 変更内容
EVAL シナリオを 2 回目に開始しようとしたときの 409 の detail を日本語の明確な文にした。

変更前: `Scenario 'EVAL1' has already been submitted by 'xxxxx' (evaluation runs are accepted once)`
変更後: `評価シナリオ 'EVAL1' は user_id 'xxxxx' で提出済みです。評価の提出は 1 回限りのため、同じシナリオは再実行できません。`

ステータスコード（409）と判定ロジックは変更なし。テストの文言アサートを更新。

## 補足
day2 ノートブックは `raise_for_status()` でサーバの detail を捨てていたため、このメッセージを参加者に見せるにはノートブック側で detail を表示する必要がある。その変更は PR #50 に含めた。

## テスト
`pytest tests/` 50 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BCQT83C1HATbRY5qeZd9W